### PR TITLE
Fix for my-domain on sandboxes

### DIFF
--- a/src/Phpforce/SoapClient/Result/LoginResult.php
+++ b/src/Phpforce/SoapClient/Result/LoginResult.php
@@ -83,7 +83,7 @@ class LoginResult
         }
 
         $match = preg_match(
-            '/https:\/\/(?<instance>[^-]+)\.salesforce\.com/',
+            '/https:\/\/(?<instance>.+)\.salesforce\.com/',
             $this->serverUrl,
             $matches
         );


### PR DESCRIPTION
Sandboxes url contains "--" when, so the instance can be considered
anything that is before the .salesforce.com

https://digitaldeer--cs1.my.salesforce.com/xxxx should take
digitaldeer--cs1.my